### PR TITLE
Add circle classification and hexagonal global regularization demo with SVG exports

### DIFF
--- a/circle_classification_demo.svg
+++ b/circle_classification_demo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="700" viewBox="0 0 15.00 13.00">
+<rect width="100%" height="100%" fill="white"/>
+<polygon points="1.50,11.50 11.50,11.50 13.50,7.50 10.50,3.50 5.50,1.50 1.50,5.50" fill="none" stroke="black" stroke-width="0.08"/>
+<text x="0.3" y="0.6" font-size="0.45">Step1: Green=internal circles, Red=boundary circles</text>
+<circle cx="3.50" cy="9.50" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="3.50" cy="9.50" r="0.08" fill="green"/>
+<circle cx="6.00" cy="9.50" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="6.00" cy="9.50" r="0.08" fill="green"/>
+<circle cx="8.50" cy="9.30" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="8.50" cy="9.30" r="0.08" fill="green"/>
+<circle cx="11.00" cy="9.20" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="11.00" cy="9.20" r="0.08" fill="green"/>
+<circle cx="3.50" cy="6.50" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="3.50" cy="6.50" r="0.08" fill="green"/>
+<circle cx="6.30" cy="6.50" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="6.30" cy="6.50" r="0.08" fill="green"/>
+<circle cx="8.70" cy="6.50" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="8.70" cy="6.50" r="0.08" fill="green"/>
+<circle cx="7.50" cy="3.50" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="7.50" cy="3.50" r="0.08" fill="green"/>
+<circle cx="11.10" cy="5.70" r="1.00" fill="none" stroke="red" stroke-width="0.07"/>
+<circle cx="11.10" cy="5.70" r="0.08" fill="red"/>
+<circle cx="4.50" cy="3.50" r="1.00" fill="none" stroke="red" stroke-width="0.07"/>
+<circle cx="4.50" cy="3.50" r="0.08" fill="red"/>
+<circle cx="10.30" cy="4.20" r="1.00" fill="none" stroke="red" stroke-width="0.07"/>
+<circle cx="10.30" cy="4.20" r="0.08" fill="red"/>
+</svg>

--- a/circle_regularized_global_demo.svg
+++ b/circle_regularized_global_demo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="700" viewBox="0 0 15.00 13.00">
+<rect width="100%" height="100%" fill="white"/>
+<polygon points="1.50,11.50 11.50,11.50 13.50,7.50 10.50,3.50 5.50,1.50 1.50,5.50" fill="none" stroke="black" stroke-width="0.08"/>
+<text x="0.3" y="0.6" font-size="0.45">Step2 global lattice regularization: green moved to hexagonal lattice</text>
+<circle cx="8.02" cy="6.66" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="8.02" cy="6.66" r="0.08" fill="green"/>
+<circle cx="7.30" cy="5.09" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="7.30" cy="5.09" r="0.08" fill="green"/>
+<circle cx="5.58" cy="4.93" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="5.58" cy="4.93" r="0.08" fill="green"/>
+<circle cx="9.03" cy="5.25" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="9.03" cy="5.25" r="0.08" fill="green"/>
+<circle cx="7.02" cy="8.07" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="7.02" cy="8.07" r="0.08" fill="green"/>
+<circle cx="6.30" cy="6.50" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="6.30" cy="6.50" r="0.08" fill="green"/>
+<circle cx="4.58" cy="6.34" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="4.58" cy="6.34" r="0.08" fill="green"/>
+<circle cx="5.30" cy="7.91" r="1.00" fill="none" stroke="green" stroke-width="0.07"/>
+<circle cx="5.30" cy="7.91" r="0.08" fill="green"/>
+<circle cx="11.10" cy="5.70" r="1.00" fill="none" stroke="red" stroke-width="0.07"/>
+<circle cx="11.10" cy="5.70" r="0.08" fill="red"/>
+<circle cx="4.50" cy="3.50" r="1.00" fill="none" stroke="red" stroke-width="0.07"/>
+<circle cx="4.50" cy="3.50" r="0.08" fill="red"/>
+<circle cx="10.30" cy="4.20" r="1.00" fill="none" stroke="red" stroke-width="0.07"/>
+<circle cx="10.30" cy="4.20" r="0.08" fill="red"/>
+</svg>

--- a/classify_circles.py
+++ b/classify_circles.py
@@ -1,0 +1,230 @@
+import math
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Set, Tuple
+
+Point = Tuple[float, float]
+
+
+@dataclass
+class CirclePoint:
+    center: Point
+    radius: float
+
+
+def point_to_segment_distance(p: Point, a: Point, b: Point) -> float:
+    px, py = p
+    ax, ay = a
+    bx, by = b
+    abx, aby = bx - ax, by - ay
+    apx, apy = px - ax, py - ay
+    ab2 = abx * abx + aby * aby
+    if ab2 == 0:
+        return math.hypot(px - ax, py - ay)
+
+    t = (apx * abx + apy * aby) / ab2
+    t = max(0.0, min(1.0, t))
+    closest_x = ax + t * abx
+    closest_y = ay + t * aby
+    return math.hypot(px - closest_x, py - closest_y)
+
+
+def point_in_polygon(point: Point, polygon: Sequence[Point]) -> bool:
+    x, y = point
+    inside = False
+    n = len(polygon)
+    for i in range(n):
+        x1, y1 = polygon[i]
+        x2, y2 = polygon[(i + 1) % n]
+        intersects = ((y1 > y) != (y2 > y)) and (
+            x < (x2 - x1) * (y - y1) / (y2 - y1 + 1e-12) + x1
+        )
+        if intersects:
+            inside = not inside
+    return inside
+
+
+def is_internal_circle(center: Point, radius: float, polygon: Sequence[Point]) -> bool:
+    if not point_in_polygon(center, polygon):
+        return False
+
+    n = len(polygon)
+    min_dist = float("inf")
+    for i in range(n):
+        a = polygon[i]
+        b = polygon[(i + 1) % n]
+        min_dist = min(min_dist, point_to_segment_distance(center, a, b))
+    return min_dist > radius
+
+
+def classify_circles(
+    polygon: Sequence[Point], circle_centers: Iterable[Point], radius: float
+) -> Tuple[List[CirclePoint], List[CirclePoint]]:
+    internal: List[CirclePoint] = []
+    boundary_related: List[CirclePoint] = []
+
+    for c in circle_centers:
+        circle = CirclePoint(center=c, radius=radius)
+        if is_internal_circle(c, radius, polygon):
+            internal.append(circle)
+        else:
+            boundary_related.append(circle)
+
+    return internal, boundary_related
+
+
+def k_nearest_indices(points: Sequence[Point], idx: int, k: int) -> List[int]:
+    dists: List[Tuple[float, int]] = []
+    x0, y0 = points[idx]
+    for j, (x, y) in enumerate(points):
+        if j == idx:
+            continue
+        dists.append((math.hypot(x - x0, y - y0), j))
+    dists.sort(key=lambda item: item[0])
+    return [j for _, j in dists[:k]]
+
+
+def build_mutual_knn_graph(points: Sequence[Point], k: int = 6) -> Dict[int, Set[int]]:
+    graph: Dict[int, Set[int]] = {i: set() for i in range(len(points))}
+    knn = {i: set(k_nearest_indices(points, i, k)) for i in range(len(points))}
+    for i in range(len(points)):
+        for j in knn[i]:
+            if i in knn[j]:
+                graph[i].add(j)
+                graph[j].add(i)
+    return graph
+
+
+def find_core_index(points: Sequence[Point]) -> int:
+    cx = sum(p[0] for p in points) / len(points)
+    cy = sum(p[1] for p in points) / len(points)
+    return min(range(len(points)), key=lambda i: math.hypot(points[i][0] - cx, points[i][1] - cy))
+
+
+def regularize_global_hexagonal(internal: Sequence[CirclePoint], radius: float) -> Tuple[List[CirclePoint], str]:
+    """Heuristic global lattice regularization.
+
+    Steps:
+    1) pick core point near centroid
+    2) require exactly 6 mutual-KNN neighbors for first ring
+    3) place first ring onto perfect hexagon around core, preserving average scale/rotation
+    4) BFS outward, snapping each new node from a fixed parent along nearest 60-degree direction
+    """
+    if len(internal) < 7:
+        return list(internal), "Not enough internal circles (<7), skip regularization."
+
+    points = [c.center for c in internal]
+    graph = build_mutual_knn_graph(points, k=min(6, len(points) - 1))
+    core = find_core_index(points)
+    ring = sorted(graph[core], key=lambda j: math.atan2(points[j][1] - points[core][1], points[j][0] - points[core][0]))
+    if len(ring) != 6:
+        return list(internal), f"Core neighbor count is {len(ring)} (not 6), skip regularization."
+
+    lattice = [tuple(p) for p in points]
+    px, py = points[core]
+
+    mean_angle = sum(math.atan2(points[j][1] - py, points[j][0] - px) for j in ring) / 6.0
+    edge_len = math.sqrt(3.0) * radius
+
+    for m, j in enumerate(ring):
+        ang = mean_angle + m * (math.pi / 3.0)
+        lattice[j] = (px + edge_len * math.cos(ang), py + edge_len * math.sin(ang))
+
+    fixed = {core, *ring}
+    queue = list(ring)
+
+    while queue:
+        parent = queue.pop(0)
+        parent_pos = lattice[parent]
+        parent_neighbors = sorted(graph[parent], key=lambda j: math.atan2(points[j][1] - points[parent][1], points[j][0] - points[parent][0]))
+
+        for nb in parent_neighbors:
+            if nb in fixed:
+                continue
+            # keep approximate original direction, snap to nearest 60-degree orientation
+            raw_ang = math.atan2(points[nb][1] - points[parent][1], points[nb][0] - points[parent][0])
+            rel = (raw_ang - mean_angle) / (math.pi / 3.0)
+            snapped = round(rel) * (math.pi / 3.0) + mean_angle
+            lattice[nb] = (
+                parent_pos[0] + edge_len * math.cos(snapped),
+                parent_pos[1] + edge_len * math.sin(snapped),
+            )
+            fixed.add(nb)
+            queue.append(nb)
+
+    out = [CirclePoint(center=lattice[i], radius=radius) for i in range(len(internal))]
+    return out, f"Regularization applied. core={core}, first-ring=6, fixed={len(fixed)}/{len(internal)}"
+
+
+def export_svg(
+    polygon: Sequence[Point],
+    internal: Sequence[CirclePoint],
+    boundary_related: Sequence[CirclePoint],
+    output_path: str,
+    title: str,
+) -> None:
+    xs = [p[0] for p in polygon] + [c.center[0] for c in internal] + [c.center[0] for c in boundary_related]
+    ys = [p[1] for p in polygon] + [c.center[1] for c in internal] + [c.center[1] for c in boundary_related]
+    min_x, max_x = min(xs), max(xs)
+    min_y, max_y = min(ys), max(ys)
+
+    pad = 1.5
+    width = max_x - min_x + 2 * pad
+    height = max_y - min_y + 2 * pad
+
+    def map_xy(p: Point) -> Point:
+        x, y = p
+        return x - min_x + pad, height - (y - min_y + pad)
+
+    polygon_points = " ".join(f"{map_xy(p)[0]:.2f},{map_xy(p)[1]:.2f}" for p in polygon)
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="920" height="700" viewBox="0 0 {width:.2f} {height:.2f}">',
+        '<rect width="100%" height="100%" fill="white"/>',
+        f'<polygon points="{polygon_points}" fill="none" stroke="black" stroke-width="0.08"/>',
+        f'<text x="0.3" y="0.6" font-size="0.45">{title}</text>',
+    ]
+
+    for c in internal:
+        cx, cy = map_xy(c.center)
+        svg.append(f'<circle cx="{cx:.2f}" cy="{cy:.2f}" r="{c.radius:.2f}" fill="none" stroke="green" stroke-width="0.07"/>')
+        svg.append(f'<circle cx="{cx:.2f}" cy="{cy:.2f}" r="0.08" fill="green"/>')
+
+    for c in boundary_related:
+        cx, cy = map_xy(c.center)
+        svg.append(f'<circle cx="{cx:.2f}" cy="{cy:.2f}" r="{c.radius:.2f}" fill="none" stroke="red" stroke-width="0.07"/>')
+        svg.append(f'<circle cx="{cx:.2f}" cy="{cy:.2f}" r="0.08" fill="red"/>')
+
+    svg.append("</svg>")
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(svg))
+
+
+def demo() -> None:
+    polygon = [(0, 0), (10, 0), (12, 4), (9, 8), (4, 10), (0, 6)]
+    centers = [
+        (2.0, 2.0), (4.5, 2.0), (7.0, 2.2), (9.5, 2.3), (2.0, 5.0),
+        (4.8, 5.0), (7.2, 5.0), (9.6, 5.8), (3.0, 8.0), (6.0, 8.0), (8.8, 7.3),
+    ]
+    radius = 1.0
+
+    internal, boundary_related = classify_circles(polygon, centers, radius)
+    print(f"Total circles: {len(centers)}")
+    print(f"Internal circles: {len(internal)}")
+    print(f"Boundary circles: {len(boundary_related)}")
+
+    export_svg(polygon, internal, boundary_related, "circle_classification_demo.svg", "Step1: Green=internal circles, Red=boundary circles")
+
+    regularized_internal, msg = regularize_global_hexagonal(internal, radius)
+    print(msg)
+    export_svg(
+        polygon,
+        regularized_internal,
+        boundary_related,
+        "circle_regularized_global_demo.svg",
+        "Step2 global lattice regularization: green moved to hexagonal lattice",
+    )
+    print("Saved figures: circle_classification_demo.svg, circle_regularized_global_demo.svg")
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
### Motivation
- Provide a small utility to classify circle centers as internal or boundary-related relative to a polygon and demonstrate a heuristic global hexagonal regularization for internal circles.
- Produce visual artifacts to inspect classification and regularization results for debugging and presentation purposes.

### Description
- Add `classify_circles.py` implementing point-in-polygon and segment distance utilities, `classify_circles`, a mutual-KNN graph builder, and a `regularize_global_hexagonal` heuristic to snap internal centers to a global hexagonal lattice.
- Implement `export_svg` to render the polygon, internal (green) and boundary-related (red) circles and a `demo()` that runs classification, regularization, and exports two SVG files.
- Include two generated example SVGs: `circle_classification_demo.svg` (pre-regularization) and `circle_regularized_global_demo.svg` (post-regularization).
- Return informative messages from `regularize_global_hexagonal` when skipping regularization due to insufficient points or unexpected neighbor counts.

### Testing
- Ran the demo script with `python classify_circles.py` as a smoke test which printed circle counts, regularization status, and successfully wrote `circle_classification_demo.svg` and `circle_regularized_global_demo.svg` (success).
- No unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eadce6b70832095816cc281ee3a30)